### PR TITLE
allow not only mobile app battery

### DIFF
--- a/blueprints/automation/awtrix_battery_monitor.yaml
+++ b/blueprints/automation/awtrix_battery_monitor.yaml
@@ -39,8 +39,7 @@ blueprint:
         entity:
           multiple: false
           filter:
-            - integration: mobile_app
-              device_class: battery
+            - device_class: battery
         # multiple: false
     message_text:
       name: Text to Display


### PR DESCRIPTION
I think there is no need to limit this for the mobile app.
Maybe for an electic car or some other battery sensors.