### PR TITLE
Fix for temp_suffix set to None

### DIFF
--- a/blueprints/automation/awtrix_weatherflow.yaml
+++ b/blueprints/automation/awtrix_weatherflow.yaml
@@ -656,7 +656,7 @@ variables:
   text_len: >-
     {%- macro get_text_len(string) %}
     {%- set length = namespace(value=0) %}
-    {%- for char in string %}
+    {%- for char in string|string() %}
       {%- if char.isdigit() %}
         {%- set length.value = length.value + 3 %}
       {%- elif char == '°' %}

--- a/blueprints/automation/awtrix_weatherflow.yaml
+++ b/blueprints/automation/awtrix_weatherflow.yaml
@@ -654,9 +654,9 @@ variables:
   text_available_width: >
     {%- if show_moon %}16{%- else %}24{%- endif %}
   text_len: >-
-    {%- macro get_text_len(string) %}
+    {%- macro get_text_len(text) %}
     {%- set length = namespace(value=0) %}
-    {%- for char in string|string() %}
+    {%- for char in text|string() %}
       {%- if char.isdigit() %}
         {%- set length.value = length.value + 3 %}
       {%- elif char == '°' %}


### PR DESCRIPTION
If `temp_suffix` is set to `None` an error shows up:
    
```
ERROR (MainThread) [homeassistant.components.automation.weather_display] Error rendering variables: TypeError: 'float' object is not iterable
```

This is caused by `get_text_len` being called with a float instead of an string which is not iterable. To solve this the argument is casted to string.