### PR TITLE
Fix invalid json when forecast hours is set to zero

### DIFF
--- a/blueprints/automation/awtrix_weatherflow.yaml
+++ b/blueprints/automation/awtrix_weatherflow.yaml
@@ -939,10 +939,10 @@ action:
                 {
                   "draw": [
                     {%- if hours_to_show > 0 %}
-                    {{draw_forecast_lines(8,hours_to_show,0)}}
+                    {{draw_forecast_lines(8,hours_to_show,0)}},
                   {%- endif %}
                   {%- if current_temp != 'unavailable' -%}
-                  ,{"dt":[{{text_x}},1,"{{temp_text}}","{{interpolate(color_dict, current_temp | float)}}"]}
+                  {"dt":[{{text_x}},1,"{{temp_text}}","{{interpolate(color_dict, current_temp | float)}}"]}
                   {%- else -%}
                   {"dt":"err"}
                   {%- endif -%}


### PR DESCRIPTION
This pull request fixes the json output when number of forecast hours is set to 0.